### PR TITLE
Update postgresql-dist.json to follow new link from enterprisedb

### DIFF
--- a/postgresql-dist.json
+++ b/postgresql-dist.json
@@ -5,8 +5,8 @@
   "architecture": {
     "64bit": {
       "url": [
-        "https://get.enterprisedb.com/postgresql/postgresql-16.1-1-windows-x64-binaries.zip",
-        "https://get.enterprisedb.com/postgresql/postgresql-16.1-1-windows-x64.exe"
+        "https://sbp.enterprisedb.com/getfile.jsp?fileid=1258791",
+        "https://sbp.enterprisedb.com/getfile.jsp?fileid=1258792"
       ],
       "hash": [
         "0179cc6d863139b68d1d1a69bdb58db766b040c6b6f2976dd1c5adf83dd0b6de",
@@ -19,14 +19,4 @@
     "url": "https://www.postgresql.org/ftp/source/",
     "regex": "v(16\\.[\\d.]+)"
   },
-  "autoupdate": {
-    "architecture": {
-      "64bit": {
-        "url": [
-          "https://get.enterprisedb.com/postgresql/postgresql-$version-1-windows-x64-binaries.zip",
-          "https://get.enterprisedb.com/postgresql/postgresql-$version-1-windows-x64.exe"
-        ]
-      }
-    }
-  }
 }


### PR DESCRIPTION
Looks like enterprisedb changed their URLs:
![image](https://github.com/cardinotGV/scoop/assets/73480455/4c7ff4e9-1092-484b-9c43-039e5d7026b6)
![image](https://github.com/cardinotGV/scoop/assets/73480455/2474668e-ebbb-4ac3-9bdb-490722754a1c)
And we won't be able to use the autoupdate feature either :(